### PR TITLE
Feature/ot292 109

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
         "@faker-js/faker": "^7.5.0",
         "@types/bcryptjs": "^2.4.2",
         "@types/express": "^4.17.14",
+        "@types/http-errors": "^1.8.2",
         "@types/jsonwebtoken": "^8.5.9",
         "@types/node": "^18.7.18",
         "@typescript-eslint/eslint-plugin": "^5.37.0",
@@ -335,6 +336,12 @@
         "@types/qs": "*",
         "@types/range-parser": "*"
       }
+    },
+    "node_modules/@types/http-errors": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-1.8.2.tgz",
+      "integrity": "sha512-EqX+YQxINb+MeXaIqYDASb6U6FCHbWjkj4a1CKDBks3d/QiB2+PqBLyO72vLDgAO1wUI4O+9gweRcQK11bTL/w==",
+      "dev": true
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.11",
@@ -4572,6 +4579,12 @@
         "@types/qs": "*",
         "@types/range-parser": "*"
       }
+    },
+    "@types/http-errors": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-1.8.2.tgz",
+      "integrity": "sha512-EqX+YQxINb+MeXaIqYDASb6U6FCHbWjkj4a1CKDBks3d/QiB2+PqBLyO72vLDgAO1wUI4O+9gweRcQK11bTL/w==",
+      "dev": true
     },
     "@types/json-schema": {
       "version": "7.0.11",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "@faker-js/faker": "^7.5.0",
     "@types/bcryptjs": "^2.4.2",
     "@types/express": "^4.17.14",
+    "@types/http-errors": "^1.8.2",
     "@types/jsonwebtoken": "^8.5.9",
     "@types/node": "^18.7.18",
     "@typescript-eslint/eslint-plugin": "^5.37.0",

--- a/src/app.ts
+++ b/src/app.ts
@@ -2,6 +2,8 @@ import {
   NextFunction, Request, Response,
 } from 'express';
 
+import createError from 'http-errors';
+import { errorHandler } from './middlewares/error.handler';
 import indexRouter from './routes/index';
 
 import usersRouter from './routes/users';
@@ -9,10 +11,9 @@ import authRouter from './routes/auth';
 import organizationRouter from './routes/organizations';
 import categoryRouter from './routes/categories';
 import newsRouter from './routes/news';
-import sendMailRouter from  './routes/sendemail';
+import sendMailRouter from './routes/sendemail';
 import activitiesRouter from './routes/activities';
 
-const createError = require('http-errors');
 const express = require('express');
 const path = require('path');
 const cookieParser = require('cookie-parser');
@@ -39,17 +40,15 @@ app.use('/users', usersRouter);
 app.use('/organization', organizationRouter);
 app.use('/sender', sendMailRouter);
 app.use('/categories', categoryRouter);
-app.use('/news',newsRouter);
+app.use('/news', newsRouter);
 app.use('/activities', activitiesRouter);
 
 // catch 404 and forward to error handler
 app.use((req: Request, res: Response, next: NextFunction) => {
-  next(createError(404));
+  const error : Error = createError(404, `Route ${req.hostname + req.path} not found`, { expose: false });
+  next(error);
 });
 
-app.use((err: any, req: Request, res: Response) => {
-  res.status(err.status || 500);
-  res.json({ error: err.message });
-});
+app.use(errorHandler);
 
 export default app;

--- a/src/middlewares/error.handler.ts
+++ b/src/middlewares/error.handler.ts
@@ -1,0 +1,42 @@
+import { Request, Response, NextFunction } from 'express';
+import createError from 'http-errors';
+
+export const logError : Function = (error: Error): void => {
+  console.error(error);
+};
+
+export const logErrorMiddleware : Function = (
+  error : Error,
+  req : Request,
+  res : Response,
+  next : NextFunction,
+) : void => {
+  logError(error);
+  next(error);
+};
+
+export function errorHandler(
+  error : any,
+  req : Request,
+  res : Response,
+  next : NextFunction,
+) : Response {
+  const statusCode = error.status || 500;
+  res.status(statusCode);
+  if (error.contents) {
+    return res.json({
+      name: error.name,
+      status: statusCode,
+      message: error.message,
+      contents: error.contents,
+    });
+  }
+  return res.json({ name: error.name, status: statusCode, message: error.message });
+}
+
+export default {
+  logError,
+  createError,
+  logErrorMiddleware,
+  errorHandler,
+};

--- a/src/validations/newsValidator.ts
+++ b/src/validations/newsValidator.ts
@@ -15,6 +15,7 @@ const schemaName = checkSchema({
     in: ['body'],
     notEmpty: {
       errorMessage: 'Name cannot be empty',
+      bail: true,
     },
     isString: {
       errorMessage: 'Name must be string',
@@ -27,6 +28,7 @@ const schemaCategoryId = checkSchema({
     in: ['body'],
     notEmpty: {
       errorMessage: 'Category ID cannot be empty',
+      bail: true,
     },
     isInt: {
       errorMessage: 'Category ID must be an integuer',
@@ -41,6 +43,7 @@ const schemaContent = checkSchema({
     in: ['body'],
     notEmpty: {
       errorMessage: 'Content cannot be empty',
+      bail: true,
     },
     isString: {
       errorMessage: 'Content must be string',
@@ -53,6 +56,7 @@ const schemaImage = checkSchema({
     in: ['body'],
     notEmpty: {
       errorMessage: 'Image cannot be empty',
+      bail: true,
     },
     isString: {
       errorMessage: 'Image must be string',

--- a/src/validations/reportErrorValidation.ts
+++ b/src/validations/reportErrorValidation.ts
@@ -1,9 +1,13 @@
 import { NextFunction, Request, Response } from 'express';
-import { validationResult } from 'express-validator';
+import { validationResult, ValidationError } from 'express-validator';
 import createError from 'http-errors';
 
+const errorValidationFormatter = ({
+  location, msg, param, value, nestedErrors,
+}: ValidationError) => `${location}[${param}]: ${msg}`;
+
 export default function reportError(req: Request, res: Response, next: NextFunction) {
-  const result = validationResult(req);
+  const result = validationResult(req).formatWith(errorValidationFormatter);
   if (!result.isEmpty()) {
     return next(createError(400, 'Input validation error', { expose: false, contents: result.array() }));
   }

--- a/src/validations/reportErrorValidation.ts
+++ b/src/validations/reportErrorValidation.ts
@@ -1,8 +1,11 @@
 import { NextFunction, Request, Response } from 'express';
 import { validationResult } from 'express-validator';
+import createError from 'http-errors';
 
 export default function reportError(req: Request, res: Response, next: NextFunction) {
-  const errors = validationResult(req);
-  if (!errors.isEmpty()) { return res.status(400).json({ errors: errors.array() }); }
+  const result = validationResult(req);
+  if (!result.isEmpty()) {
+    return next(createError(400, 'Input validation error', { expose: false, contents: result.array() }));
+  }
   return next();
 }


### PR DESCRIPTION
## Sumary
- add types http-errors
- add error handler
- use error handler in app file
- add http-error in reportError file (express-validator) and formatter
### [Ticket](https://alkemy-labs.atlassian.net/browse/OT292-109)
## How to create a new http-error
```
import createError from 'http-errors';
// ... 
const error = createError(statusCode , 'Some title' , { expose: false });
const error = createError(statusCode , new Error('Some title') , { expose: false });
const error = createError(statusCode , err.message , { expose: false });
next(error);
```
## Output format
- ####  General
```
{
    "name": string,
    "status": number,
    "message": string
}
```
- #### Validator

```
{
    "name": string,
    "status": number,
    "message": string,
    "contents": [
        string,
        string
    ]
}
```
## Evidence
![image](https://user-images.githubusercontent.com/62780657/192658844-554c7f93-5b8e-4c63-b51a-93f380e63e55.png)
![image](https://user-images.githubusercontent.com/62780657/192659250-b4ce2839-6900-4abe-9fad-a0fb3ce68c7e.png)

